### PR TITLE
Prune hop headers, read-only storage

### DIFF
--- a/internal/storage/filesystem.go
+++ b/internal/storage/filesystem.go
@@ -140,6 +140,7 @@ func (fs *FSStorage) RootCreateFrom(hash string) (string, *Root, error) {
 		return "", nil, fmt.Errorf("hash not found in index: %s", hash)
 	}
 	root := newRootHash(fs, hash)
+	root.readonly = false
 	fs.roots[u] = root
 	return u, root, nil
 }

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -95,6 +95,7 @@ func (m *MemStorage) RootCreateFrom(hash string) (string, *Root, error) {
 		return "", nil, fmt.Errorf("hash not found in index: %s", hash)
 	}
 	root := newRootHash(m, hash)
+	root.readonly = false
 	m.roots[u] = root
 	return u, root, nil
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -9,7 +9,10 @@ import (
 	"github.com/httplock/httplock/internal/config"
 )
 
-var errNotImplemented = errors.New("not implemented")
+var (
+	errNotImplemented = errors.New("not implemented")
+	errReadOnly       = errors.New("read only")
+)
 
 const (
 	filenameIndexJSON = "index.json"


### PR DESCRIPTION
Hop headers need to be deleted before filtering. And dealing with a hash instead of a uuid should understand the storage is read-only and not try to send the upstream request.

Signed-off-by: Brandon Mitchell <git@bmitch.net>