### PR TITLE
Update version method to use runtime/debug

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,9 +73,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
-    - name: Version
-      run: make embed/version.json
-
     # - name: Set up QEMU
     #   uses: docker/setup-qemu-action@v1
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ artifacts/
 bin/
 vendor/
 local-test/
-embed/version.json

--- a/Makefile
+++ b/Makefile
@@ -60,13 +60,7 @@ swagger: $(GOPATH)/bin/swag .FORCE ## Update swagger docs
 vendor: ## Vendor Go modules
 	go mod vendor
 
-embed/version.json: .FORCE
-	# docker builds will not have the .dockerignore inside the container
-	if [ -f ".dockerignore" -o ! -f "embed/version.json" ]; then \
-		echo "{\"VCSRef\": \"$(VCS_REF)\", \"VCSTag\": \"$(VCS_TAG)\"}" >embed/version.json; \
-	fi
-
-binaries: vendor embed/version.json $(BINARIES) ## Build Go binaries
+binaries: vendor $(BINARIES) ## Build Go binaries
 
 bin/httplock: .FORCE
 	CGO_ENABLED=0 go build ${GO_BUILD_FLAGS} -o bin/httplock .
@@ -82,7 +76,7 @@ ui: .FORCE ## Build the UI files
 
 docker: $(IMAGES) ## Build the docker image
 
-docker-httplock: embed/version.json .FORCE
+docker-httplock: .FORCE
 	docker build -t httplock/httplock -f Dockerfile$(DOCKERFILE_EXT) $(DOCKER_ARGS) .
 	docker build -t httplock/httplock:alpine -f Dockerfile$(DOCKERFILE_EXT) --target release-alpine $(DOCKER_ARGS) .
 

--- a/internal/template/printpretty.go
+++ b/internal/template/printpretty.go
@@ -1,0 +1,27 @@
+package template
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+type prettyPrinter interface {
+	MarshalPretty() ([]byte, error)
+}
+
+func printPretty(v interface{}) string {
+	if pp, ok := v.(prettyPrinter); ok {
+		b, err := pp.MarshalPretty()
+		if err != nil {
+			return ""
+		}
+		return string(b)
+	}
+	// fall through for objects without a prettyPrinter interface
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	enc.Encode(v)
+	return buf.String()
+}

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -1,0 +1,89 @@
+// Package template wraps a common set of templates around text/template
+package template
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"reflect"
+	"strings"
+	gotemplate "text/template"
+)
+
+var tmplFuncs = gotemplate.FuncMap{
+	"default": func(def, orig interface{}) interface{} {
+		if orig == nil || orig == reflect.Zero(reflect.TypeOf(orig)).Interface() {
+			return def
+		}
+		return orig
+	},
+	"env": func(key string) string {
+		return os.Getenv(key)
+	},
+	"file": func(filename string) string {
+		b, err := os.ReadFile(filename)
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(string(b))
+	},
+	"join": strings.Join,
+	"json": func(v interface{}) string {
+		buf := &bytes.Buffer{}
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		enc.Encode(v)
+		return buf.String()
+	},
+	"jsonPretty": func(v interface{}) string {
+		buf := &bytes.Buffer{}
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		enc.SetIndent("", "  ")
+		enc.Encode(v)
+		return buf.String()
+	},
+	"printPretty": printPretty,
+	"lower":       strings.ToLower,
+	"split":       strings.Split,
+	"time":        func() *TimeFuncs { return &TimeFuncs{} },
+	"upper":       strings.ToUpper,
+}
+
+// Opt allows options to be passed to templating functions
+type Opt func(*gotemplate.Template) (*gotemplate.Template, error)
+
+// Writer outputs a template to an io.Writer
+func Writer(out io.Writer, tmpl string, data interface{}, opts ...Opt) error {
+	var err error
+	t := gotemplate.New("out").Funcs(tmplFuncs)
+	for _, opt := range opts {
+		t, err = opt(t)
+		if err != nil {
+			return err
+		}
+	}
+	t, err = t.Parse(tmpl)
+	if err != nil {
+		return err
+	}
+	return t.Execute(out, data)
+}
+
+// String converts a template to a string
+func String(tmpl string, data interface{}, opts ...Opt) (string, error) {
+	var sb strings.Builder
+	err := Writer(&sb, tmpl, data)
+	if err != nil {
+		return "", err
+	}
+	return sb.String(), nil
+}
+
+// WithFuncs includes additional template functions
+func WithFuncs(funcs gotemplate.FuncMap) Opt {
+	return func(t *gotemplate.Template) (*gotemplate.Template, error) {
+		return t.Funcs(funcs), nil
+	}
+}

--- a/internal/template/time.go
+++ b/internal/template/time.go
@@ -1,0 +1,23 @@
+package template
+
+import (
+	"time"
+)
+
+// // TimeFunc provides the "time" template, returning a struct with methods
+// func TimeFunc() *TimeFuncs {
+// 	return &TimeFuncs{}
+// }
+
+// TimeFuncs wraps all time based templates
+type TimeFuncs struct{}
+
+// Now returns current time
+func (t *TimeFuncs) Now() time.Time {
+	return time.Now()
+}
+
+// Parse parses the current time according to layout
+func (t *TimeFuncs) Parse(layout string, value string) (time.Time, error) {
+	return time.Parse(layout, value)
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,31 @@
+// Package version returns details on the Go and Git repo used in the build
+package version
+
+import (
+	"bytes"
+	"fmt"
+	"text/tabwriter"
+)
+
+const (
+	stateClean    = "clean"
+	stateDirty    = "dirty"
+	unknown       = "unknown"
+	biVCSDate     = "vcs.time"
+	biVCSCommit   = "vcs.revision"
+	biVCSModified = "vcs.modified"
+)
+
+func (i Info) MarshalPretty() ([]byte, error) {
+	buf := &bytes.Buffer{}
+	tw := tabwriter.NewWriter(buf, 0, 0, 1, ' ', 0)
+	fmt.Fprintf(tw, "VCSRef:\t%s\n", i.VCSRef)
+	fmt.Fprintf(tw, "VCSCommit:\t%s\n", i.VCSCommit)
+	fmt.Fprintf(tw, "VCSState:\t%s\n", i.VCSState)
+	fmt.Fprintf(tw, "VCSDate:\t%s\n", i.VCSDate)
+	fmt.Fprintf(tw, "Platform:\t%s\n", i.Platform)
+	fmt.Fprintf(tw, "GoVer:\t%s\n", i.GoVer)
+	fmt.Fprintf(tw, "GoCompiler:\t%s\n", i.GoCompiler)
+	tw.Flush()
+	return buf.Bytes(), nil
+}

--- a/internal/version/version_buildinfo.go
+++ b/internal/version/version_buildinfo.go
@@ -1,0 +1,70 @@
+//go:build go1.18
+// +build go1.18
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"time"
+)
+
+type Info struct {
+	GoVer      string           `json:"goVersion"`       // go version
+	GoCompiler string           `json:"goCompiler"`      // go compiler
+	Platform   string           `json:"platform"`        // os/arch
+	VCSCommit  string           `json:"vcsCommit"`       // commit sha
+	VCSDate    string           `json:"vcsDate"`         // commit date in RFC3339 format
+	VCSRef     string           `json:"vcsRef"`          // commit sha + dirty if state is not clean
+	VCSState   string           `json:"vcsState"`        // clean or dirty
+	VCSTag     string           `json:"-"`               // tag is not available from Go
+	Debug      *debug.BuildInfo `json:"debug,omitempty"` // build info debugging data
+}
+
+func GetInfo() Info {
+	i := Info{
+		GoVer:     unknown,
+		Platform:  unknown,
+		VCSCommit: unknown,
+		VCSDate:   unknown,
+		VCSRef:    unknown,
+		VCSState:  unknown,
+		VCSTag:    "",
+	}
+
+	i.GoVer = runtime.Version()
+	i.GoCompiler = runtime.Compiler
+	i.Platform = fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
+
+	if bi, ok := debug.ReadBuildInfo(); ok && bi != nil {
+		i.Debug = bi
+		date := biSetting(bi, biVCSDate)
+		if t, err := time.Parse(time.RFC3339, date); err == nil {
+			i.VCSDate = t.UTC().Format(time.RFC3339)
+		}
+		i.VCSCommit = biSetting(bi, biVCSCommit)
+		i.VCSRef = i.VCSCommit
+		modified := biSetting(bi, biVCSModified)
+		if modified == "true" {
+			i.VCSState = stateDirty
+			i.VCSRef += "-" + stateDirty
+		} else if modified == "false" {
+			i.VCSState = stateClean
+		}
+	}
+
+	return i
+}
+
+func biSetting(bi *debug.BuildInfo, key string) string {
+	if bi == nil {
+		return unknown
+	}
+	for _, setting := range bi.Settings {
+		if setting.Key == key {
+			return setting.Value
+		}
+	}
+	return unknown
+}

--- a/internal/version/version_old.go
+++ b/internal/version/version_old.go
@@ -1,0 +1,38 @@
+//go:build !go1.18
+// +build !go1.18
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+type Info struct {
+	GoVer      string `json:"goVersion"`  // go version
+	GoCompiler string `json:"goCompiler"` // go compiler
+	Platform   string `json:"platform"`   // os/arch
+	VCSCommit  string `json:"vcsCommit"`  // commit sha
+	VCSDate    string `json:"vcsDate"`    // commit date in RFC3339 format
+	VCSRef     string `json:"vcsRef"`     // commit sha + dirty if state is not clean
+	VCSState   string `json:"vcsState"`   // clean or dirty
+	VCSTag     string `json:"-"`          // tag
+}
+
+func GetInfo() Info {
+	i := Info{
+		GoVer:     unknown,
+		Platform:  unknown,
+		VCSCommit: unknown,
+		VCSDate:   unknown,
+		VCSRef:    unknown,
+		VCSState:  unknown,
+		VCSTag:    "",
+	}
+
+	i.GoVer = runtime.Version()
+	i.GoCompiler = runtime.Compiler
+	i.Platform = fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
+
+	return i
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,16 @@
+package version
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	i := GetInfo()
+	ij, err := json.MarshalIndent(i, "", "  ")
+	if err != nil {
+		t.Errorf("failed to marshal info: %v", err)
+		return
+	}
+	t.Logf("received info:\n%s", string(ij))
+}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ var (
 var rootOpts struct {
 	verbosity string
 	confFile  string
+	format    string // for Go template formatting of various commands
 }
 
 var rootCmd = &cobra.Command{


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Describe the change

This updates `httplock version` to use Go's runtime/debug methods instead of injecting the version from an embedded json file.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```
$ bin/httplock version
VCSRef:     b0d2c9cba9bba1e024156731bf700eec0452b1dc
VCSCommit:  b0d2c9cba9bba1e024156731bf700eec0452b1dc
VCSState:   clean
VCSDate:    2022-10-02T00:16:48Z
Platform:   linux/amd64
GoVer:      go1.19
GoCompiler: gc
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

Update the version method to use `runtime/debug`
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
